### PR TITLE
fixed remaining elements to be able to pull data from Duke

### DIFF
--- a/src/aiodukeenergy/dukeenergy.py
+++ b/src/aiodukeenergy/dukeenergy.py
@@ -44,12 +44,12 @@ class DukeEnergy:
     @property
     def internal_user_id(self) -> str | None:
         """Get the internal user ID from auth response."""
-        return self._auth.get("cdp_internal_user_id") if self._auth else None
+        return self._auth.get("internalUserID") if self._auth else None
 
     @property
     def email(self) -> str | None:
         """Get the email from auth response."""
-        return self._auth.get("email") if self._auth else None
+        return self._auth.get("loginEmailAddress") if self._auth else None
 
     async def close(self) -> None:
         """Close the SolarEdge API client."""
@@ -197,18 +197,12 @@ class DukeEnergy:
         # map results to an object from start to end date by interval with values from
         # result["Series1"] array for energy and result["Series3"] array for temperature
         # first, loop through a range of dates from start to end date by interval
-        energy = result["Series1"]
-        energy_len = len(energy)
-        temp = result["Series3"]
-        temp_len = len(temp)
         num_values = (end_date - start_date).days + 1
+        result_len = len(result["usageArray"])
 
-        # if interval is hourly, multiply the number of values by 24 and repeat the
-        # temperature values for each hour
+        # if interval is hourly, multiply the number of values by 24
         if interval == "HOURLY":
             num_values = num_values * 24
-            temp = [t for t in temp for _ in range(24)]
-            temp_len = len(temp)
 
         data = {}
         missing = []
@@ -223,18 +217,18 @@ class DukeEnergy:
                 if interval == "HOURLY"
                 else date.strftime("%m/%d/%Y")
             )
-            if result["TickSeries"][n] != expected_series:
+            if result['usageArray'][n]['date'] != expected_series:
                 missing.append(date)
                 offset += 1
                 continue
 
-            if n >= energy_len or not energy[n] > 0:
+            if n >= result_len or not float(result['usageArray'][n]['usage']) > 0:
                 missing.append(date)
                 continue
 
             data[date] = {
-                "energy": energy[n] if n < energy_len else None,
-                "temperature": temp[n] if n < temp_len else None,
+                "energy": float(result['usageArray'][n]['usage']) if n < result_len else None,
+                "temperature": result['usageArray'][n]['temperatureAvg'] if n < result_len else None,
             }
 
         return {"data": data, "missing": missing}


### PR DESCRIPTION
Data was successfully pulled in to HA after this update.

internal_user_id: changed key from cdp_internal_user_id to internalUserID

mail: changed key from email to loginEmailAddress

get_energy_usage: this was the main part needing updating as the data returned from Duke is different. It appears previously energy and temperature data was returned in different elements. Now, it's all in one array. The energy used values are strings in the data and had to be converted to floats when stored in the returned data.

<!--
  😀 Wonderful!  Thank you for opening a pull request.

  By submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/hunterjm/aiodukeenergy/blob/main/.github/CODE_OF_CONDUCT.md).

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following to merge this PR.

  Note that there is no problem if they are not checked when this PR is created.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [ ] Code is up-to-date with the `main` branch
- [ ] This pull request follows the [contributing guidelines](https://github.com/hunterjm/aiodukeenergy/blob/main/CONTRIBUTING.md).
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests".

> - If pre-commit.ci is failing, try `pre-commit run -a` for further information.
> - If CI / test is failing, try `poetry run pytest` for further information.

<!--
  🎉 Thank you for contributing!
-->
